### PR TITLE
Add support for creating multiple vc

### DIFF
--- a/behaviors/createVC.py
+++ b/behaviors/createVC.py
@@ -3,6 +3,9 @@ from discord.ext import commands
 from discord_slash import cog_ext, SlashContext
 
 
+global NewId
+NewId = []
+
 class CreateVC(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
@@ -30,8 +33,7 @@ class CreateVC(commands.Cog):
             guild = ctx.guild
             channel = await guild.create_voice_channel(channel_name, user_limit=member_cap)
             await ctx.send(f"I created the voice channel `{channel_name}`!")
-            global NewId
-            NewId = channel.id
+            NewId.append(channel.id)
             await ctx.author.move_to(channel=channel)
             print(voice_state)
             print(NewId)

--- a/bot.py
+++ b/bot.py
@@ -34,12 +34,14 @@ async def on_ready():
 @bot.event
 async def on_voice_state_update(member, before, after):
   from behaviors.createVC import NewId
-  if before.channel is not None: 
-   if before.channel.id != 610818618325729285: # DO NOT REMOVE!!!!!
-     if before.channel.id == NewId:
-      if len(before.channel.members) == 0:
-        print("channel is now empty")
-        await before.channel.delete()
+  if len(NewId) > 0:
+    if before.channel is not None: 
+      if before.channel.id != 610818618325729285: # DO NOT REMOVE!!!!!
+        if before.channel.id in NewId:
+          if len(before.channel.members) == 0:
+            NewId.remove(before.channel.id)
+            print("channel is now empty")
+            await before.channel.delete()
   
 
   


### PR DESCRIPTION
This change should allow for multiple voice chats at the same time. 

This is done by changing NewId into a list which contains all the channels that have been created. Then removing them from the NewId list when deleting the channel. Thus using NewId to remember what channels have been created.

**Has not been tested as i did not bother creating a discord bot to test with**